### PR TITLE
Use mail settings from config instead of hard-coded settings

### DIFF
--- a/humanist_app/helpers.py
+++ b/humanist_app/helpers.py
@@ -1,9 +1,9 @@
 from django.core.mail import send_mail, get_connection  # noqa
 from django.contrib.auth.models import User
 from django.conf import settings
+
+
 # Send a single email
-
-
 class Email():
     to = None
     sender = None
@@ -12,8 +12,8 @@ class Email():
 
     def send(self):
         if self.to and self.sender and self.subject and self.body:
-            connection = get_connection(host='smtp.kdl.kcl.ac.uk',
-                                        port=25)
+            connection = get_connection(host=settings.EMAIL_HOST,
+                                        port=settings.EMAIL_PORT)
             try:
                 if not type(self.to) == 'list':
                     self.to = [self.to]


### PR DESCRIPTION
The helpers.py used hard-coded mail settings for the mail connection instead of using the ones specified in the local settings.

This could probably changed to simply ```get_connection()``` since EMAIL_HOST and EMAIL_PORT are used by default.